### PR TITLE
add testing logger package

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -4,7 +4,7 @@ package micrologger
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"time"
 
 	kitlog "github.com/go-kit/kit/log"
@@ -30,7 +30,7 @@ func DefaultConfig() Config {
 		Caller: func() interface{} {
 			return fmt.Sprintf("%+v", stack.Caller(4))
 		},
-		IOWriter: ioutil.Discard,
+		IOWriter: os.Stdout,
 		TimestampFormatter: func() interface{} {
 			return time.Now().UTC().Format("06-01-02 15:04:05.000")
 		},

--- a/microloggertest/logger.go
+++ b/microloggertest/logger.go
@@ -1,0 +1,22 @@
+package microloggertest
+
+import (
+	"io/ioutil"
+
+	"github.com/giantswarm/micrologger"
+)
+
+// New returns a Logger intance configured to discard its output.
+func New() micrologger.Logger {
+	c := micrologger.DefaultConfig()
+	{
+		c.IOWriter = ioutil.Discard
+	}
+
+	logger, err := micrologger.New(c)
+	if err != nil {
+		panic(err)
+	}
+
+	return logger
+}

--- a/microloggertest/logger_test.go
+++ b/microloggertest/logger_test.go
@@ -1,0 +1,8 @@
+package microloggertest
+
+import "testing"
+
+func TestNew(t *testing.T) {
+	// Test if New doesn't panic.
+	New()
+}


### PR DESCRIPTION
* default logger logs to stdout
* test logger logs to /dev/null

With that change we can create logger with `logger, err := micrologger.New(micrologger.DefaultConfig())`.

For testing it's enough to create logger with `microloggertest.New()` - it doesn't return error and it's tested to not panic.

Package naming follows Go convention you can see in `httptest` package: https://golang.org/pkg/net/http/httptest/