### PR TITLE
Change timestamp format to four digit year

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -32,7 +32,7 @@ func DefaultConfig() Config {
 		},
 		IOWriter: os.Stdout,
 		TimestampFormatter: func() interface{} {
-			return time.Now().UTC().Format("06-01-02 15:04:05.000")
+			return time.Now().UTC().Format("2006-01-02 15:04:05.000")
 		},
 	}
 }


### PR DESCRIPTION
This should make our timestamps ISO-compatible and easier to read, since it eliminates the "what is what" question when looking at a string like `17-11-16`.