### PR TITLE
added basic activation key logger

### DIFF
--- a/activation_key_logger.go
+++ b/activation_key_logger.go
@@ -41,6 +41,33 @@ type activationLogger struct {
 	activations map[string]interface{}
 }
 
+// NewActivation creates a new activation key logger. This logger kind can be
+// used on command line tools to improve situations in which log filtering using
+// other command line tools like grep is not sufficient. Due to certain filter
+// mechanisms this Logger implementation should not be used in performance
+// critical applications. The idea of the activation key logger is to have a
+// multi dimensional log filter mechanism. This logger here provides three
+// different features which can be combined and used simultaneously at will.
+//
+//     Filtering arbitrary key-value pairs. The structured nature of the Logger
+//     interface expects key-value pairs to be logged. The activation key logger
+//     can be configured with any kind of activation key-pairs which, when
+//     configured, all have to match against an emitted logging call, in order
+//     to be dispatched. In case none, or not all activation keys match, the
+//     emitted logging call is going to be ignored.
+//
+//     Filtering log levels works using the special log levels debug, info,
+//     warning and error. The level based nature of this activation mechanism is
+//     that lower log levels match just like exact log levels match. When the
+//     Logger is configured to activate on info log levels, the Logger will
+//     activate on debug related logs, as well as info related logs, but not on
+//     warning or error related logs.
+//
+//     Filtering log verbosity works similar like the log level mechanism, but
+//     on arbitrary verbosity levels, which are represented as numbers. As long
+//     as the configured verbosity is higher or equal to the perceived verbosity
+//     obtained by the emitted logging call, the log will be dispatched.
+//
 func NewActivation(config ActivationLoggerConfig) (Logger, error) {
 	if config.Underlying == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Underlying must not be empty", config)

--- a/activation_key_logger.go
+++ b/activation_key_logger.go
@@ -1,0 +1,68 @@
+package micrologger
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+type ActivationKeyConfig struct {
+	Underlying Logger
+
+	ActivationKeys []string
+}
+
+type activationKeyLogger struct {
+	underlying Logger
+
+	activationKeys []string
+}
+
+func NewActivationKey(config ActivationKeyConfig) (Logger, error) {
+	if config.Underlying == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Underlying must not be empty", config)
+	}
+
+	l := &activationKeyLogger{
+		underlying: config.Underlying,
+
+		activationKeys: config.ActivationKeys,
+	}
+
+	return l, nil
+}
+
+func (l *activationKeyLogger) Log(keyVals ...interface{}) error {
+	activated, err := shouldActivate(l.activationKeys, keyVals...)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if activated {
+		return l.underlying.Log(keyVals...)
+	}
+
+	return nil
+}
+
+func (l *activationKeyLogger) LogCtx(ctx context.Context, keyVals ...interface{}) error {
+	activated, err := shouldActivate(l.activationKeys, keyVals...)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if activated {
+		return l.underlying.LogCtx(ctx, keyVals...)
+	}
+
+	return nil
+}
+
+func (l *activationKeyLogger) With(keyVals ...interface{}) Logger {
+	return l.underlying.With(keyVals...)
+}
+
+// TODO implement properly.
+func shouldActivate(activationKeys []string, keyVals ...interface{}) (bool, error) {
+	return false, nil
+}

--- a/activation_key_logger_test.go
+++ b/activation_key_logger_test.go
@@ -107,6 +107,148 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 			},
 			ExpectedResult: true,
 		},
+
+		// Case 8, activation keys matching values of the keyVals result in false,
+		// because we only want to activate on matching keys.
+		{
+			ActivationKeys: []string{
+				"val",
+			},
+			KeyVals: []interface{}{
+				"key",
+				"val",
+			},
+			ExpectedResult: false,
+		},
+
+		// Case 9, activation keys matching keys of the keyVals still result in true
+		// even if values match as well.
+		{
+			ActivationKeys: []string{
+				"key",
+				"val",
+			},
+			KeyVals: []interface{}{
+				"key",
+				"val",
+				"val",
+				"key",
+			},
+			ExpectedResult: true,
+		},
+
+		// Case 10, activation keys must all match in order to result in true.
+		{
+			ActivationKeys: []string{
+				"foo",
+				"bar",
+				"baz",
+			},
+			KeyVals: []interface{}{
+				"foo",
+				"val",
+				"bar",
+				"val",
+				"baz",
+				"val",
+			},
+			ExpectedResult: true,
+		},
+
+		// Case 11, not all activation keys matching results in false.
+		{
+			ActivationKeys: []string{
+				"foo",
+				"bar",
+				"baz",
+			},
+			KeyVals: []interface{}{
+				"foo",
+				"val",
+				"bar",
+				"val",
+				"notmatching",
+				"val",
+			},
+			ExpectedResult: false,
+		},
+
+		// Case 12, activation keys representing common log levels result in true
+		// when matching.
+		{
+			ActivationKeys: []string{
+				"info",
+			},
+			KeyVals: []interface{}{
+				"test",
+				3,
+				"info",
+				"val",
+			},
+			ExpectedResult: true,
+		},
+
+		// Case 13, same as 12 but with a different log level.
+		{
+			ActivationKeys: []string{
+				"error",
+			},
+			KeyVals: []interface{}{
+				"test",
+				3,
+				"error",
+				"val",
+			},
+			ExpectedResult: true,
+		},
+
+		// Case 14, activation keys representing common log levels result in true
+		// when matching lower log levels. The activation key info matches the log
+		// level debug because debug is lower than info.
+		{
+			ActivationKeys: []string{
+				"info",
+			},
+			KeyVals: []interface{}{
+				"test",
+				3,
+				"debug",
+				"val",
+			},
+			ExpectedResult: true,
+		},
+
+		// Case 15, activation keys representing common log levels result in false
+		// when not matching lower log levels. The activation key info does not
+		// match the log level warn because warn is higher than info.
+		{
+			ActivationKeys: []string{
+				"info",
+			},
+			KeyVals: []interface{}{
+				"test",
+				3,
+				"warn",
+				"val",
+			},
+			ExpectedResult: false,
+		},
+
+		// Case 16, activation keys representing common log levels result in false
+		// when not matching lower log levels. The activation key info does not
+		// match the log level error because error is higher than info.
+		{
+			ActivationKeys: []string{
+				"info",
+			},
+			KeyVals: []interface{}{
+				"test",
+				3,
+				"error",
+				"val",
+			},
+			ExpectedResult: false,
+		},
 	}
 
 	for i, tc := range testCases {

--- a/activation_key_logger_test.go
+++ b/activation_key_logger_test.go
@@ -1,0 +1,122 @@
+package micrologger
+
+import (
+	"testing"
+)
+
+func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
+	testCases := []struct {
+		ActivationKeys []string
+		KeyVals        []interface{}
+		ExpectedResult bool
+	}{
+		// Case 0, zero value input results into false, because logging should not
+		// be activated in case no match exists, even if the input is empty.
+		{
+			ActivationKeys: nil,
+			KeyVals:        nil,
+			ExpectedResult: false,
+		},
+
+		// Case 1, same as 0 but with empty lists instead of zero values.
+		{
+			ActivationKeys: []string{},
+			KeyVals:        []interface{}{},
+			ExpectedResult: false,
+		},
+
+		// Case 2, a given activation key not matching any keyVals results into
+		// false.
+		{
+			ActivationKeys: []string{
+				"foo",
+			},
+			KeyVals:        nil,
+			ExpectedResult: false,
+		},
+
+		// Case 3, same as 2 but with different activation keys.
+		// false.
+		{
+			ActivationKeys: []string{
+				"foo",
+				"foo",
+				"bar",
+				"baz",
+			},
+			KeyVals:        nil,
+			ExpectedResult: false,
+		},
+
+		// Case 4, same as 2 but with given keyVals which still do not match.
+		{
+			ActivationKeys: []string{
+				"foo",
+			},
+			KeyVals: []interface{}{
+				"test",
+				3,
+				"key",
+				"val",
+			},
+			ExpectedResult: false,
+		},
+
+		// Case 5, same as 4 but with different activation keys.
+		{
+			ActivationKeys: []string{
+				"foo",
+				"foo",
+				"bar",
+				"baz",
+			},
+			KeyVals: []interface{}{
+				"test",
+				3,
+				"key",
+				"val",
+			},
+			ExpectedResult: false,
+		},
+
+		// Case 6, a given activation key matching any keyVals results into true.
+		{
+			ActivationKeys: []string{
+				"test",
+			},
+			KeyVals: []interface{}{
+				"test",
+				3,
+				"key",
+				"val",
+			},
+			ExpectedResult: true,
+		},
+
+		// Case 7, same as 6 but with different matching activation keys.
+		{
+			ActivationKeys: []string{
+				"test",
+				"key",
+			},
+			KeyVals: []interface{}{
+				"test",
+				3,
+				"key",
+				"val",
+			},
+			ExpectedResult: true,
+		},
+	}
+
+	for i, tc := range testCases {
+		result, err := shouldActivate(tc.ActivationKeys, tc.KeyVals)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i, nil, err)
+		}
+
+		if result != tc.ExpectedResult {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedResult, result)
+		}
+	}
+}

--- a/activation_key_logger_test.go
+++ b/activation_key_logger_test.go
@@ -58,8 +58,8 @@ func Test_ActivationKeyLogger_shouldActivate_arbitrary(t *testing.T) {
 		KeyVals        []interface{}
 		ExpectedResult bool
 	}{
-		// Case 0, a given activation key not matching any keyVals results into
-		// false.
+		// Case 0, a given activation does not match any keyVals and results into
+		// false when the list of KeyVals is empty.
 		{
 			Activations: map[string]interface{}{
 				"foo": "bar",
@@ -68,8 +68,7 @@ func Test_ActivationKeyLogger_shouldActivate_arbitrary(t *testing.T) {
 			ExpectedResult: false,
 		},
 
-		// Case 1, a given activation key not matching any keyVals results into
-		// false.
+		// Case 1, same as 0 but with different activation keys.
 		{
 			Activations: map[string]interface{}{
 				"foo": 3,
@@ -78,8 +77,7 @@ func Test_ActivationKeyLogger_shouldActivate_arbitrary(t *testing.T) {
 			ExpectedResult: false,
 		},
 
-		// Case 2, same as 2 but with different activation keys.
-		// false.
+		// Case 2, same as 0 but with different activation keys.
 		{
 			Activations: map[string]interface{}{
 				"foo": "bar",
@@ -90,7 +88,8 @@ func Test_ActivationKeyLogger_shouldActivate_arbitrary(t *testing.T) {
 			ExpectedResult: false,
 		},
 
-		// Case 3, same as 2 but with given keyVals which still do not match.
+		// Case 3, a given activation does not match any keyVals and results into
+		// false when the list of KeyVals is not empty.
 		{
 			Activations: map[string]interface{}{
 				"foo": "bar",
@@ -104,7 +103,7 @@ func Test_ActivationKeyLogger_shouldActivate_arbitrary(t *testing.T) {
 			ExpectedResult: false,
 		},
 
-		// Case 4, same as 4 but with different activation keys.
+		// Case 4, same as 3 but with different activation keys.
 		{
 			Activations: map[string]interface{}{
 				"foo": "bar",
@@ -134,7 +133,7 @@ func Test_ActivationKeyLogger_shouldActivate_arbitrary(t *testing.T) {
 			ExpectedResult: true,
 		},
 
-		// Case 6, same as 6 but with different matching activation keys.
+		// Case 6, same as 5 but with different activation keys.
 		{
 			Activations: map[string]interface{}{
 				"test": 3,
@@ -149,36 +148,7 @@ func Test_ActivationKeyLogger_shouldActivate_arbitrary(t *testing.T) {
 			ExpectedResult: true,
 		},
 
-		// Case 7, activation keys matching values of the keyVals result in false,
-		// because we only want to activate on matching keys.
-		{
-			Activations: map[string]interface{}{
-				"val": "key",
-			},
-			KeyVals: []interface{}{
-				"key",
-				"val",
-			},
-			ExpectedResult: false,
-		},
-
-		// Case 8, activation keys matching keys of the keyVals still result in true
-		// even if values match as well.
-		{
-			Activations: map[string]interface{}{
-				"key": "val",
-				"val": "key",
-			},
-			KeyVals: []interface{}{
-				"key",
-				"val",
-				"val",
-				"key",
-			},
-			ExpectedResult: true,
-		},
-
-		// Case 9, activation keys must all match in order to result in true.
+		// Case 7, activation keys must all match in order to result in true.
 		{
 			Activations: map[string]interface{}{
 				"foo": "val",
@@ -248,7 +218,7 @@ func Test_ActivationKeyLogger_shouldActivate_level(t *testing.T) {
 			ExpectedResult: true,
 		},
 
-		// Case 1, same as 12 but with a different log level.
+		// Case 1, same as 0 but with a different log level.
 		{
 			Activations: map[string]interface{}{
 				"level": "error",
@@ -263,8 +233,8 @@ func Test_ActivationKeyLogger_shouldActivate_level(t *testing.T) {
 		},
 
 		// Case 2, activation keys representing common log levels result in true
-		// when matching lower log levels. The activation key info matches the log
-		// level debug because debug is lower than info.
+		// when matching lower log levels. The activation key level/info matches the
+		// log level debug because debug is lower than info.
 		{
 			Activations: map[string]interface{}{
 				"level": "info",
@@ -279,8 +249,8 @@ func Test_ActivationKeyLogger_shouldActivate_level(t *testing.T) {
 		},
 
 		// Case 3, activation keys representing common log levels result in false
-		// when not matching lower log levels. The activation key info does not
-		// match the log level warning because warning is higher than info.
+		// when not matching lower log levels. The activation key level/info does
+		// not match the log level warning because warning is higher than info.
 		{
 			Activations: map[string]interface{}{
 				"level": "info",
@@ -295,8 +265,8 @@ func Test_ActivationKeyLogger_shouldActivate_level(t *testing.T) {
 		},
 
 		// Case 4, activation keys representing common log levels result in false
-		// when not matching lower log levels. The activation key info does not
-		// match the log level error because error is higher than info.
+		// when not matching lower log levels. The activation key level/info does
+		// not match the log level error because error is higher than info.
 		{
 			Activations: map[string]interface{}{
 				"level": "info",
@@ -310,7 +280,7 @@ func Test_ActivationKeyLogger_shouldActivate_level(t *testing.T) {
 			ExpectedResult: false,
 		},
 
-		// Case 5, ... .
+		// Case 5, log level and verbosity matches together result in true.
 		{
 			Activations: map[string]interface{}{
 				"level":     "info",
@@ -327,33 +297,17 @@ func Test_ActivationKeyLogger_shouldActivate_level(t *testing.T) {
 			ExpectedResult: true,
 		},
 
-		// Case 6, ... .
+		// Case 6, same as 5 but with different log level and verbosity.
 		{
 			Activations: map[string]interface{}{
-				"level":     "info",
-				"verbosity": 3,
+				"level":     "error",
+				"verbosity": 5,
 			},
 			KeyVals: []interface{}{
 				"level",
-				"info",
+				"error",
 				"verbosity",
-				3,
-				"message",
-				"test",
-			},
-			ExpectedResult: true,
-		},
-
-		// Case 7, ... independent of verbosity .
-		{
-			Activations: map[string]interface{}{
-				"level": "info",
-			},
-			KeyVals: []interface{}{
-				"level",
-				"info",
-				"verbosity",
-				15,
+				5,
 				"message",
 				"test",
 			},
@@ -379,7 +333,7 @@ func Test_ActivationKeyLogger_shouldActivate_verbosity(t *testing.T) {
 		KeyVals        []interface{}
 		ExpectedResult bool
 	}{
-		// Case 0, ... .
+		// Case 0, exact verbosity matching results in true.
 		{
 			Activations: map[string]interface{}{
 				"verbosity": 3,
@@ -395,7 +349,7 @@ func Test_ActivationKeyLogger_shouldActivate_verbosity(t *testing.T) {
 			ExpectedResult: true,
 		},
 
-		// Case 1, ... .
+		// Case 1, same as 0 but with different verbosity.
 		{
 			Activations: map[string]interface{}{
 				"verbosity": 6,
@@ -411,7 +365,8 @@ func Test_ActivationKeyLogger_shouldActivate_verbosity(t *testing.T) {
 			ExpectedResult: true,
 		},
 
-		// Case 2, ... .
+		// Case 2, activation verbosity matching lower verbosity in keyVals results
+		// in true.
 		{
 			Activations: map[string]interface{}{
 				"verbosity": 6,
@@ -427,7 +382,8 @@ func Test_ActivationKeyLogger_shouldActivate_verbosity(t *testing.T) {
 			ExpectedResult: true,
 		},
 
-		// Case 3, ... .
+		// Case 3, activation verbosity compared to higher verbosity in keyVals does
+		// not match and results in false.
 		{
 			Activations: map[string]interface{}{
 				"verbosity": 6,

--- a/activation_key_logger_test.go
+++ b/activation_key_logger_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 )
 
-func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
+func Test_ActivationKeyLogger_shouldActivate_zeroValue(t *testing.T) {
 	testCases := []struct {
-		Activations    map[string]string
+		Activations    map[string]interface{}
 		KeyVals        []interface{}
 		ExpectedResult bool
 	}{
@@ -20,25 +20,68 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 
 		// Case 1, same as 0 but with empty lists instead of zero values.
 		{
-			Activations:    map[string]string{},
+			Activations:    map[string]interface{}{},
 			KeyVals:        []interface{}{},
 			ExpectedResult: false,
 		},
 
-		// Case 2, a given activation key not matching any keyVals results into
+		// Case 2, same as 0 but with different input.
+		{
+			Activations:    nil,
+			KeyVals:        []interface{}{},
+			ExpectedResult: false,
+		},
+
+		// Case 3, same as 0 but with different input.
+		{
+			Activations:    map[string]interface{}{},
+			KeyVals:        nil,
+			ExpectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		result, err := shouldActivate(tc.Activations, tc.KeyVals)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i, nil, err)
+		}
+
+		if result != tc.ExpectedResult {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedResult, result)
+		}
+	}
+}
+
+func Test_ActivationKeyLogger_shouldActivate_arbitrary(t *testing.T) {
+	testCases := []struct {
+		Activations    map[string]interface{}
+		KeyVals        []interface{}
+		ExpectedResult bool
+	}{
+		// Case 0, a given activation key not matching any keyVals results into
 		// false.
 		{
-			Activations: map[string]string{
+			Activations: map[string]interface{}{
 				"foo": "bar",
 			},
 			KeyVals:        nil,
 			ExpectedResult: false,
 		},
 
-		// Case 3, same as 2 but with different activation keys.
+		// Case 1, a given activation key not matching any keyVals results into
 		// false.
 		{
-			Activations: map[string]string{
+			Activations: map[string]interface{}{
+				"foo": 3,
+			},
+			KeyVals:        nil,
+			ExpectedResult: false,
+		},
+
+		// Case 2, same as 2 but with different activation keys.
+		// false.
+		{
+			Activations: map[string]interface{}{
 				"foo": "bar",
 				"bar": "foo",
 				"baz": "foo",
@@ -47,9 +90,9 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 			ExpectedResult: false,
 		},
 
-		// Case 4, same as 2 but with given keyVals which still do not match.
+		// Case 3, same as 2 but with given keyVals which still do not match.
 		{
-			Activations: map[string]string{
+			Activations: map[string]interface{}{
 				"foo": "bar",
 			},
 			KeyVals: []interface{}{
@@ -61,9 +104,9 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 			ExpectedResult: false,
 		},
 
-		// Case 5, same as 4 but with different activation keys.
+		// Case 4, same as 4 but with different activation keys.
 		{
-			Activations: map[string]string{
+			Activations: map[string]interface{}{
 				"foo": "bar",
 				"bar": "foo",
 				"baz": "foo",
@@ -77,10 +120,10 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 			ExpectedResult: false,
 		},
 
-		// Case 6, a given activation key matching any keyVals results into true.
+		// Case 5, a given activation key matching any keyVals results into true.
 		{
-			Activations: map[string]string{
-				"test": "*",
+			Activations: map[string]interface{}{
+				"test": 3,
 			},
 			KeyVals: []interface{}{
 				"test",
@@ -91,11 +134,11 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 			ExpectedResult: true,
 		},
 
-		// Case 7, same as 6 but with different matching activation keys.
+		// Case 6, same as 6 but with different matching activation keys.
 		{
-			Activations: map[string]string{
-				"test": "*",
-				"key":  "*",
+			Activations: map[string]interface{}{
+				"test": 3,
+				"key":  "val",
 			},
 			KeyVals: []interface{}{
 				"test",
@@ -106,11 +149,11 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 			ExpectedResult: true,
 		},
 
-		// Case 8, activation keys matching values of the keyVals result in false,
+		// Case 7, activation keys matching values of the keyVals result in false,
 		// because we only want to activate on matching keys.
 		{
-			Activations: map[string]string{
-				"val": "*",
+			Activations: map[string]interface{}{
+				"val": "key",
 			},
 			KeyVals: []interface{}{
 				"key",
@@ -119,12 +162,12 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 			ExpectedResult: false,
 		},
 
-		// Case 9, activation keys matching keys of the keyVals still result in true
+		// Case 8, activation keys matching keys of the keyVals still result in true
 		// even if values match as well.
 		{
-			Activations: map[string]string{
-				"key": "*",
-				"val": "*",
+			Activations: map[string]interface{}{
+				"key": "val",
+				"val": "key",
 			},
 			KeyVals: []interface{}{
 				"key",
@@ -135,12 +178,12 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 			ExpectedResult: true,
 		},
 
-		// Case 10, activation keys must all match in order to result in true.
+		// Case 9, activation keys must all match in order to result in true.
 		{
-			Activations: map[string]string{
-				"foo": "*",
-				"bar": "*",
-				"baz": "*",
+			Activations: map[string]interface{}{
+				"foo": "val",
+				"bar": "val",
+				"baz": "val",
 			},
 			KeyVals: []interface{}{
 				"foo",
@@ -153,12 +196,12 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 			ExpectedResult: true,
 		},
 
-		// Case 11, not all activation keys matching results in false.
+		// Case 10, not all activation keys matching results in false.
 		{
-			Activations: map[string]string{
-				"foo": "*",
-				"bar": "*",
-				"baz": "*",
+			Activations: map[string]interface{}{
+				"foo": "val",
+				"bar": "val",
+				"baz": "val",
 			},
 			KeyVals: []interface{}{
 				"foo",
@@ -170,116 +213,234 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 			},
 			ExpectedResult: false,
 		},
+	}
 
-		// Case 12, activation keys representing common log levels result in true
+	for i, tc := range testCases {
+		result, err := shouldActivate(tc.Activations, tc.KeyVals)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i, nil, err)
+		}
+
+		if result != tc.ExpectedResult {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedResult, result)
+		}
+	}
+}
+
+func Test_ActivationKeyLogger_shouldActivate_level(t *testing.T) {
+	testCases := []struct {
+		Activations    map[string]interface{}
+		KeyVals        []interface{}
+		ExpectedResult bool
+	}{
+		// Case 0, activation keys representing common log levels result in true
 		// when matching.
 		{
-			Activations: map[string]string{
-				"info": "*",
+			Activations: map[string]interface{}{
+				"level": "info",
 			},
 			KeyVals: []interface{}{
 				"test",
 				3,
+				"level",
 				"info",
-				"val",
 			},
 			ExpectedResult: true,
 		},
 
-		// Case 13, same as 12 but with a different log level.
+		// Case 1, same as 12 but with a different log level.
 		{
-			Activations: map[string]string{
-				"error": "*",
+			Activations: map[string]interface{}{
+				"level": "error",
 			},
 			KeyVals: []interface{}{
 				"test",
 				3,
+				"level",
 				"error",
-				"val",
 			},
 			ExpectedResult: true,
 		},
 
-		// Case 14, activation keys representing common log levels result in true
+		// Case 2, activation keys representing common log levels result in true
 		// when matching lower log levels. The activation key info matches the log
 		// level debug because debug is lower than info.
 		{
-			Activations: map[string]string{
-				"info": "*",
+			Activations: map[string]interface{}{
+				"level": "info",
 			},
 			KeyVals: []interface{}{
 				"test",
 				3,
+				"level",
 				"debug",
-				"val",
 			},
 			ExpectedResult: true,
 		},
 
-		// Case 15, activation keys representing common log levels result in false
+		// Case 3, activation keys representing common log levels result in false
 		// when not matching lower log levels. The activation key info does not
-		// match the log level warn because warn is higher than info.
+		// match the log level warning because warning is higher than info.
 		{
-			Activations: map[string]string{
-				"info": "*",
+			Activations: map[string]interface{}{
+				"level": "info",
 			},
 			KeyVals: []interface{}{
 				"test",
 				3,
-				"warn",
-				"val",
+				"level",
+				"warning",
 			},
 			ExpectedResult: false,
 		},
 
-		// Case 16, activation keys representing common log levels result in false
+		// Case 4, activation keys representing common log levels result in false
 		// when not matching lower log levels. The activation key info does not
 		// match the log level error because error is higher than info.
 		{
-			Activations: map[string]string{
-				"info": "*",
+			Activations: map[string]interface{}{
+				"level": "info",
 			},
 			KeyVals: []interface{}{
 				"test",
 				3,
+				"level",
 				"error",
-				"val",
 			},
 			ExpectedResult: false,
 		},
 
-		// Case 17, ... .
+		// Case 5, ... .
 		{
-			Activations: map[string]string{
+			Activations: map[string]interface{}{
 				"level":     "info",
-				"verbosity": "3",
+				"verbosity": 3,
 			},
 			KeyVals: []interface{}{
 				"level",
 				"info",
 				"verbosity",
-				"3",
+				3,
 				"message",
 				"test",
 			},
 			ExpectedResult: true,
 		},
 
-		// Case 18, ... .
+		// Case 6, ... .
 		{
-			Activations: map[string]string{
+			Activations: map[string]interface{}{
 				"level":     "info",
-				"verbosity": "3",
+				"verbosity": 3,
 			},
 			KeyVals: []interface{}{
 				"level",
 				"info",
 				"verbosity",
-				"3",
+				3,
 				"message",
 				"test",
 			},
 			ExpectedResult: true,
+		},
+
+		// Case 7, ... independent of verbosity .
+		{
+			Activations: map[string]interface{}{
+				"level": "info",
+			},
+			KeyVals: []interface{}{
+				"level",
+				"info",
+				"verbosity",
+				15,
+				"message",
+				"test",
+			},
+			ExpectedResult: true,
+		},
+	}
+
+	for i, tc := range testCases {
+		result, err := shouldActivate(tc.Activations, tc.KeyVals)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i, nil, err)
+		}
+
+		if result != tc.ExpectedResult {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedResult, result)
+		}
+	}
+}
+
+func Test_ActivationKeyLogger_shouldActivate_verbosity(t *testing.T) {
+	testCases := []struct {
+		Activations    map[string]interface{}
+		KeyVals        []interface{}
+		ExpectedResult bool
+	}{
+		// Case 0, ... .
+		{
+			Activations: map[string]interface{}{
+				"verbosity": 3,
+			},
+			KeyVals: []interface{}{
+				"level",
+				"info",
+				"verbosity",
+				3,
+				"message",
+				"test",
+			},
+			ExpectedResult: true,
+		},
+
+		// Case 1, ... .
+		{
+			Activations: map[string]interface{}{
+				"verbosity": 6,
+			},
+			KeyVals: []interface{}{
+				"level",
+				"info",
+				"verbosity",
+				6,
+				"message",
+				"test",
+			},
+			ExpectedResult: true,
+		},
+
+		// Case 2, ... .
+		{
+			Activations: map[string]interface{}{
+				"verbosity": 6,
+			},
+			KeyVals: []interface{}{
+				"level",
+				"info",
+				"verbosity",
+				2,
+				"message",
+				"test",
+			},
+			ExpectedResult: true,
+		},
+
+		// Case 3, ... .
+		{
+			Activations: map[string]interface{}{
+				"verbosity": 6,
+			},
+			KeyVals: []interface{}{
+				"level",
+				"info",
+				"verbosity",
+				12,
+				"message",
+				"test",
+			},
+			ExpectedResult: false,
 		},
 	}
 

--- a/activation_key_logger_test.go
+++ b/activation_key_logger_test.go
@@ -6,21 +6,21 @@ import (
 
 func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 	testCases := []struct {
-		ActivationKeys []string
+		Activations    map[string]string
 		KeyVals        []interface{}
 		ExpectedResult bool
 	}{
 		// Case 0, zero value input results into false, because logging should not
 		// be activated in case no match exists, even if the input is empty.
 		{
-			ActivationKeys: nil,
+			Activations:    nil,
 			KeyVals:        nil,
 			ExpectedResult: false,
 		},
 
 		// Case 1, same as 0 but with empty lists instead of zero values.
 		{
-			ActivationKeys: []string{},
+			Activations:    map[string]string{},
 			KeyVals:        []interface{}{},
 			ExpectedResult: false,
 		},
@@ -28,8 +28,8 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 		// Case 2, a given activation key not matching any keyVals results into
 		// false.
 		{
-			ActivationKeys: []string{
-				"foo",
+			Activations: map[string]string{
+				"foo": "bar",
 			},
 			KeyVals:        nil,
 			ExpectedResult: false,
@@ -38,11 +38,10 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 		// Case 3, same as 2 but with different activation keys.
 		// false.
 		{
-			ActivationKeys: []string{
-				"foo",
-				"foo",
-				"bar",
-				"baz",
+			Activations: map[string]string{
+				"foo": "bar",
+				"bar": "foo",
+				"baz": "foo",
 			},
 			KeyVals:        nil,
 			ExpectedResult: false,
@@ -50,8 +49,8 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 
 		// Case 4, same as 2 but with given keyVals which still do not match.
 		{
-			ActivationKeys: []string{
-				"foo",
+			Activations: map[string]string{
+				"foo": "bar",
 			},
 			KeyVals: []interface{}{
 				"test",
@@ -64,11 +63,10 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 
 		// Case 5, same as 4 but with different activation keys.
 		{
-			ActivationKeys: []string{
-				"foo",
-				"foo",
-				"bar",
-				"baz",
+			Activations: map[string]string{
+				"foo": "bar",
+				"bar": "foo",
+				"baz": "foo",
 			},
 			KeyVals: []interface{}{
 				"test",
@@ -81,8 +79,8 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 
 		// Case 6, a given activation key matching any keyVals results into true.
 		{
-			ActivationKeys: []string{
-				"test",
+			Activations: map[string]string{
+				"test": "*",
 			},
 			KeyVals: []interface{}{
 				"test",
@@ -95,9 +93,9 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 
 		// Case 7, same as 6 but with different matching activation keys.
 		{
-			ActivationKeys: []string{
-				"test",
-				"key",
+			Activations: map[string]string{
+				"test": "*",
+				"key":  "*",
 			},
 			KeyVals: []interface{}{
 				"test",
@@ -111,8 +109,8 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 		// Case 8, activation keys matching values of the keyVals result in false,
 		// because we only want to activate on matching keys.
 		{
-			ActivationKeys: []string{
-				"val",
+			Activations: map[string]string{
+				"val": "*",
 			},
 			KeyVals: []interface{}{
 				"key",
@@ -124,9 +122,9 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 		// Case 9, activation keys matching keys of the keyVals still result in true
 		// even if values match as well.
 		{
-			ActivationKeys: []string{
-				"key",
-				"val",
+			Activations: map[string]string{
+				"key": "*",
+				"val": "*",
 			},
 			KeyVals: []interface{}{
 				"key",
@@ -139,10 +137,10 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 
 		// Case 10, activation keys must all match in order to result in true.
 		{
-			ActivationKeys: []string{
-				"foo",
-				"bar",
-				"baz",
+			Activations: map[string]string{
+				"foo": "*",
+				"bar": "*",
+				"baz": "*",
 			},
 			KeyVals: []interface{}{
 				"foo",
@@ -157,10 +155,10 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 
 		// Case 11, not all activation keys matching results in false.
 		{
-			ActivationKeys: []string{
-				"foo",
-				"bar",
-				"baz",
+			Activations: map[string]string{
+				"foo": "*",
+				"bar": "*",
+				"baz": "*",
 			},
 			KeyVals: []interface{}{
 				"foo",
@@ -176,8 +174,8 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 		// Case 12, activation keys representing common log levels result in true
 		// when matching.
 		{
-			ActivationKeys: []string{
-				"info",
+			Activations: map[string]string{
+				"info": "*",
 			},
 			KeyVals: []interface{}{
 				"test",
@@ -190,8 +188,8 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 
 		// Case 13, same as 12 but with a different log level.
 		{
-			ActivationKeys: []string{
-				"error",
+			Activations: map[string]string{
+				"error": "*",
 			},
 			KeyVals: []interface{}{
 				"test",
@@ -206,8 +204,8 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 		// when matching lower log levels. The activation key info matches the log
 		// level debug because debug is lower than info.
 		{
-			ActivationKeys: []string{
-				"info",
+			Activations: map[string]string{
+				"info": "*",
 			},
 			KeyVals: []interface{}{
 				"test",
@@ -222,8 +220,8 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 		// when not matching lower log levels. The activation key info does not
 		// match the log level warn because warn is higher than info.
 		{
-			ActivationKeys: []string{
-				"info",
+			Activations: map[string]string{
+				"info": "*",
 			},
 			KeyVals: []interface{}{
 				"test",
@@ -238,8 +236,8 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 		// when not matching lower log levels. The activation key info does not
 		// match the log level error because error is higher than info.
 		{
-			ActivationKeys: []string{
-				"info",
+			Activations: map[string]string{
+				"info": "*",
 			},
 			KeyVals: []interface{}{
 				"test",
@@ -249,10 +247,44 @@ func Test_ActivationKeyLogger_shouldActivate(t *testing.T) {
 			},
 			ExpectedResult: false,
 		},
+
+		// Case 17, ... .
+		{
+			Activations: map[string]string{
+				"level":     "info",
+				"verbosity": "3",
+			},
+			KeyVals: []interface{}{
+				"level",
+				"info",
+				"verbosity",
+				"3",
+				"message",
+				"test",
+			},
+			ExpectedResult: true,
+		},
+
+		// Case 18, ... .
+		{
+			Activations: map[string]string{
+				"level":     "info",
+				"verbosity": "3",
+			},
+			KeyVals: []interface{}{
+				"level",
+				"info",
+				"verbosity",
+				"3",
+				"message",
+				"test",
+			},
+			ExpectedResult: true,
+		},
 	}
 
 	for i, tc := range testCases {
-		result, err := shouldActivate(tc.ActivationKeys, tc.KeyVals)
+		result, err := shouldActivate(tc.Activations, tc.KeyVals)
 		if err != nil {
 			t.Fatalf("case %d expected %#v got %#v", i, nil, err)
 		}


### PR DESCRIPTION
The idea here is to provide a logger which can be used for composing loggers via `Logger.With` in order to filter/activate logging based on certain keys in the `keyVals` provided to `Logger.Log` or `Logger.LogCtx`. E.g. we can use this for improving logging in command line tools. The logger implemented here provides a general primitive any command line tool can just use and expose via its own flags. That way for instance `opsctl` can provide flags like `--log-level=debug` and `--verbosity=5`. The corresponding go code to emit logs would then look like this. 

```
logger.Log("message", "...")
logger.Log("message", "...", "arbitrary activation key", "arbitrary activation value")
logger.Log("message", "...", "level", "debug")
logger.Log("message", "...", "verbosity", 5)
logger.Log("message", "...", "level", "error", "verbosity", 2)
```