### PR TITLE
update in ISO format DefaultTimeStamp

### DIFF
--- a/default.go
+++ b/default.go
@@ -15,5 +15,5 @@ var DefaultCaller = func() interface{} {
 var DefaultIOWriter = os.Stdout
 
 var DefaultTimestampFormatter = func() interface{} {
-	return time.Now().UTC().Format("2006-01-02 15:04:05.000")
+	return time.Now().UTC().Format("2006-01-02T15:04:05.999999-07:00")
 }


### PR DESCRIPTION
Signed-off-by: Julien Garcia Gonzalez <julien@giantswarm.io>

In order to log properly in Elasticsearch, the Default timestamp format return an ISO format.