### PR TITLE
microloggertest: don't discard logs

### DIFF
--- a/microloggertest/logger.go
+++ b/microloggertest/logger.go
@@ -1,16 +1,12 @@
 package microloggertest
 
 import (
-	"io/ioutil"
-
 	"github.com/giantswarm/micrologger"
 )
 
-// New returns a Logger intance configured to discard its output.
+// New returns a Logger intance or panics if the creation fails.
 func New() micrologger.Logger {
-	c := micrologger.Config{
-		IOWriter: ioutil.Discard,
-	}
+	c := micrologger.Config{}
 
 	logger, err := micrologger.New(c)
 	if err != nil {


### PR DESCRIPTION
We don't use `-v` flag with `go test`. This means for tests that pass we
do not see stdout. For tests that fail the diagnostic information in
the logs is actually useful.

Example: https://circleci.com/gh/giantswarm/helmclient/461?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link