### PR TITLE
changelog, docs: add changelog and PR template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/giantswarm/micrologger/tree/master

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,3 @@
+## Checklist
+
+- [ ] Update changelog in CHANGELOG.md.


### PR DESCRIPTION
I'd like to release versions v0.1.0 and v0.2.0 similarly to microerror.

## Checklist

- [x] Update changelog in CHANGELOG.md.