### PR TITLE
Pin microerror version to v0.1.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  branch = "master"
-  digest = "1:9c432418e5180be62a4bf565761eb2c618fc4ff9b7efa9a260c92068f453e28a"
+  digest = "1:98e9dc8d46288ca1cbcd2925710b5fc684514ddba062e109f35a40ad5e81de8f"
   name = "github.com/giantswarm/microerror"
   packages = ["."]
   pruneopts = ""
-  revision = "a8d5d4f526c526b4b773062958847fe7e0b7f449"
+  revision = "e8fe0fa9c0097ca80d8b773e1d728843447f9233"
+  version = "v0.1.0"
 
 [[projects]]
   digest = "1:44ec1082ba97d89ce860abcc6ee3f0cf24e658d3efb8531b0f0a52f0781e4243"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,7 +22,7 @@
 
 
 [[constraint]]
-  version = "v0.1.0"
+  version = "~0.1.0"
   name = "github.com/giantswarm/microerror"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,7 +22,7 @@
 
 
 [[constraint]]
-  branch = "master"
+  version = "v0.1.0"
   name = "github.com/giantswarm/microerror"
 
 [[constraint]]

--- a/vendor/github.com/giantswarm/microerror/.circleci/config.yml
+++ b/vendor/github.com/giantswarm/microerror/.circleci/config.yml
@@ -10,6 +10,8 @@ jobs:
         chmod +x ./architect
         ./architect version
     - run: ./architect build
+    - store_test_results:
+        path: /tmp/results
     - deploy:
         command: |
           if [ "${CIRCLE_BRANCH}" == "master" ]; then

--- a/vendor/github.com/giantswarm/microerror/CHANGELOG.md
+++ b/vendor/github.com/giantswarm/microerror/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] 2020-02-03
+
+### Added
+
+- First release.
+
+[Unreleased]: https://github.com/giantswarm/microerror/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/giantswarm/microerror/releases/tag/v0.1.0

--- a/vendor/github.com/giantswarm/microerror/DCO
+++ b/vendor/github.com/giantswarm/microerror/DCO
@@ -1,0 +1,36 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/vendor/github.com/giantswarm/microerror/LICENSE
+++ b/vendor/github.com/giantswarm/microerror/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Giant Swarm GmbH
+   Copyright 2016 - 2019 Giant Swarm GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vendor/github.com/giantswarm/microerror/README.md
+++ b/vendor/github.com/giantswarm/microerror/README.md
@@ -1,3 +1,6 @@
+[![godoc](https://img.shields.io/badge/godoc-reference-5272B4.svg)](https://godoc.org/github.com/giantswarm/microerror)
+[![CircleCI](https://circleci.com/gh/giantswarm/microerror.svg?style=shield&circle-token=f40c341b2c40c9aa5852fda592755a8f8aedc983)](https://circleci.com/gh/giantswarm/microerror)
+
 # microerror
 
 Go library to facilitate error handling, based on [juju/errgo](https://github.com/juju/errgo)

--- a/vendor/github.com/giantswarm/microerror/docs/pull_request_template.md
+++ b/vendor/github.com/giantswarm/microerror/docs/pull_request_template.md
@@ -1,0 +1,3 @@
+## Checklist
+
+- [ ] Update changelog in CHANGELOG.md.

--- a/vendor/github.com/giantswarm/microerror/error.go
+++ b/vendor/github.com/giantswarm/microerror/error.go
@@ -10,7 +10,7 @@ import "encoding/json"
 // once emitted during runtime.
 //
 //     var notEnoughWorkersError = &microerror.Error{
-//         Desc: "The amount of requested guest cluster workers exceeds the available number of host cluster nodes.",
+//         Desc: "The amount of requested tenant cluster workers exceeds the available number of control plane nodes.",
 //         Docs: "https://github.com/giantswarm/ops-recipes/blob/master/349-not-enough-workers.md",
 //         Kind: "notEnoughWorkersError",
 //     }
@@ -26,11 +26,7 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
-	if e.Desc == "" {
-		return e.String()
-	} else {
-		return e.Desc
-	}
+	return toStringCase(e.Kind)
 }
 
 func (e *Error) GoString() string {

--- a/vendor/github.com/giantswarm/microerror/error_test.go
+++ b/vendor/github.com/giantswarm/microerror/error_test.go
@@ -16,7 +16,7 @@ func Test_Error(t *testing.T) {
 	err = Mask(testError)
 
 	got := fmt.Sprintf("%#v\n", err)
-	r, err := regexp.Compile(`[.* {{"desc":"","docs":"","kind":"testError"}}]`)
+	r, err := regexp.Compile(`[.* test error]`)
 	if err != nil {
 		t.Fatalf("expected %#v got %#v", nil, err)
 	}

--- a/vendor/github.com/giantswarm/microerror/funcs.go
+++ b/vendor/github.com/giantswarm/microerror/funcs.go
@@ -1,0 +1,43 @@
+package microerror
+
+import (
+	"fmt"
+
+	"github.com/juju/errgo"
+)
+
+// Stack prints the error with the stack if its argument is underlying
+// microerror error or result of Error function otherwise. Its main purpose is
+// to be used for a value for "stack" micrologger key.
+//
+// Example:
+//
+//	logger.LogCtx(ctx, "level", "error", "message", "failed to do a thing", "stack", microerror.Stack(err))
+//
+func Stack(err error) string {
+	switch err.(type) {
+	case nil:
+		return fmt.Sprintf("%v", nil)
+	case *errgo.Err:
+		return fmt.Sprintf("%#v", err)
+	default:
+		return err.Error()
+	}
+}
+
+// Desc returns the description of a microerror.Error.
+func Desc(err error) string {
+	c := Cause(err)
+	switch c.(type) {
+	case nil:
+		return ""
+	case *Error:
+		e, ok := c.(*Error)
+		if ok {
+			return e.Desc
+		}
+		return ""
+	default:
+		return ""
+	}
+}

--- a/vendor/github.com/giantswarm/microerror/funcs_test.go
+++ b/vendor/github.com/giantswarm/microerror/funcs_test.go
@@ -1,0 +1,89 @@
+package microerror
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+func Test_Stack(t *testing.T) {
+	testCases := []struct {
+		name                string
+		inputErr            error
+		expectedStackRegexp string
+	}{
+		{
+			name:                "case 0: annotated microerror error",
+			inputErr:            Maskf(&Error{Kind: "testKind"}, "annotation"),
+			expectedStackRegexp: `^\[\{[a-zA-Z_/-]*/src/github.com/giantswarm/microerror/funcs_test.go:\d+: annotation\} \{test kind\}\]$`,
+		},
+		{
+			name:                "case 1: non annotated microerror error",
+			inputErr:            &Error{Kind: "testKind"},
+			expectedStackRegexp: "^test kind$",
+		},
+		{
+			name:                "case 2: external error",
+			inputErr:            errors.New("external error"),
+			expectedStackRegexp: "^external error$",
+		},
+		{
+			name:                "case 3: nil",
+			inputErr:            nil,
+			expectedStackRegexp: "^<nil>$",
+		},
+	}
+
+	for i, tc := range testCases {
+		re, err := regexp.Compile(tc.expectedStackRegexp)
+		if err != nil {
+			t.Fatalf("err = %q, want nil", Stack(err))
+		}
+
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			stack := Stack(tc.inputErr)
+			if !re.MatchString(stack) {
+				t.Fatalf("stack = %q, want matching regexp %#q", stack, tc.expectedStackRegexp)
+			}
+		})
+	}
+}
+
+func Test_Desc(t *testing.T) {
+	testCases := []struct {
+		name         string
+		inputErr     error
+		expectedDesc string
+	}{
+		{
+			name:         "case 0: microerror without Desc",
+			inputErr:     Maskf(&Error{Kind: "testKind"}, "annotation"),
+			expectedDesc: "",
+		},
+		{
+			name:         "case 1: microerror with Desc",
+			inputErr:     &Error{Kind: "testKind", Desc: "test description"},
+			expectedDesc: "test description",
+		},
+		{
+			name:         "case 2: external error",
+			inputErr:     errors.New("external error"),
+			expectedDesc: "",
+		},
+		{
+			name:         "case 3: nil",
+			inputErr:     nil,
+			expectedDesc: "",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			desc := Desc(tc.inputErr)
+			if desc != tc.expectedDesc {
+				t.Fatalf("desc = %q, expected %q", desc, tc.expectedDesc)
+			}
+		})
+	}
+}

--- a/vendor/github.com/giantswarm/microerror/spec.go
+++ b/vendor/github.com/giantswarm/microerror/spec.go
@@ -3,10 +3,16 @@ package microerror
 type Handler interface {
 	// New returns a new error with the given error message. It is
 	// a drop-in replacement for errors.New from the standard library.
+	//
+	// NOTE deprecated
+	//
 	New(s string) error
 
 	// Newf returns a new error with the given printf-formatted error
 	// message.
+	//
+	// NOTE deprecated
+	//
 	Newf(f string, v ...interface{}) error
 
 	// Cause returns the cause of the given error. If the cause of the err can not

--- a/vendor/github.com/giantswarm/microerror/string_case.go
+++ b/vendor/github.com/giantswarm/microerror/string_case.go
@@ -1,0 +1,35 @@
+package microerror
+
+import (
+	"strings"
+	"unicode"
+)
+
+func toStringCase(input string) string {
+	chunks := []string{}
+	split := strings.Split(input, "")
+
+	for i, s := range split {
+		r := []rune(s)
+
+		var nextUpper bool
+		if i != 0 && i+1 < len(split) {
+			p := []rune(split[i-1])
+			n := []rune(split[i+1])
+			nextUpper = unicode.IsUpper(p[0]) && unicode.IsUpper(n[0])
+		}
+
+		isFirst := i == 0
+		isLast := i+1 == len(split)
+		isUpper := unicode.IsUpper(r[0])
+		isAbbreviation := isUpper && nextUpper
+
+		if !isAbbreviation && !isFirst && !isLast && isUpper {
+			chunks = append(chunks, string(" "))
+		}
+
+		chunks = append(chunks, strings.ToLower(s))
+	}
+
+	return strings.Join(chunks, "")
+}

--- a/vendor/github.com/giantswarm/microerror/string_case_test.go
+++ b/vendor/github.com/giantswarm/microerror/string_case_test.go
@@ -1,0 +1,88 @@
+package microerror
+
+import (
+	"testing"
+)
+
+func Test_toStringCase(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		InputString    string
+		ExpectedString string
+	}{
+		{
+			Name:           "case 0: camel case to string case with lower start",
+			InputString:    "fooBar",
+			ExpectedString: "foo bar",
+		},
+		{
+			Name:           "case 1: camel case to string case with lower start and longer input",
+			InputString:    "fooBarBazupKick",
+			ExpectedString: "foo bar bazup kick",
+		},
+		{
+			Name:           "case 2: camel case to string case with upper start",
+			InputString:    "FooBar",
+			ExpectedString: "foo bar",
+		},
+		{
+			Name:           "case 3: camel case to string case with upper start and longer input",
+			InputString:    "FooBarBazupKick",
+			ExpectedString: "foo bar bazup kick",
+		},
+		{
+			Name:           "case 4: real private error kind",
+			InputString:    "authenticationError",
+			ExpectedString: "authentication error",
+		},
+		{
+			Name:           "case 5: real public error kind",
+			InputString:    "AuthenticationError",
+			ExpectedString: "authentication error",
+		},
+		{
+			Name:           "case 6: camel case with abbreviation at the start",
+			InputString:    "APINotAvailableError",
+			ExpectedString: "api not available error",
+		},
+		{
+			Name:           "case 7: camel case with abbreviation in the middle",
+			InputString:    "invalidHTTPStatusError",
+			ExpectedString: "invalid http status error",
+		},
+		{
+			Name:           "case 8: camel case with abbreviation at the end",
+			InputString:    "fooBarBAZ",
+			ExpectedString: "foo bar baz",
+		},
+		{
+			Name:           "case 9: with version numbers at the start",
+			InputString:    "v2RouteNotReachable",
+			ExpectedString: "v2 route not reachable",
+		},
+		{
+			Name:           "case 10: with version numbers in the middle",
+			InputString:    "oldV2RouteNotReachable",
+			ExpectedString: "old v2 route not reachable",
+		},
+		{
+			Name:           "case 11: with version numbers in the middle",
+			InputString:    "oldV2RouteNotReachable",
+			ExpectedString: "old v2 route not reachable",
+		},
+		{
+			Name:           "case 12: with version numbers at the end does not work",
+			InputString:    "statusCode200",
+			ExpectedString: "status code200",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			output := toStringCase(tc.InputString)
+			if output != tc.ExpectedString {
+				t.Fatalf("expected %#v got %#v", tc.ExpectedString, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We should pin or dependency on microerror, since newer versions have breaking changes.

## Checklist

- [x] Update changelog in CHANGELOG.md.
