### PR TITLE
Fix isVerbosityAllowed default case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `isVerbosityAllowed` default case (log verbosity undefined).
 
 
 ## [0.3.3] - 2020-09-15

--- a/activation_logger.go
+++ b/activation_logger.go
@@ -174,7 +174,7 @@ func isVerbosityAllowed(keyVals []interface{}, aVal interface{}) bool {
 		return activationVerbosity >= keyValsVerbosity
 	}
 
-	return false
+	return true
 }
 
 func shouldActivate(activations map[string]interface{}, keyVals []interface{}) (bool, error) {

--- a/activation_logger_test.go
+++ b/activation_logger_test.go
@@ -408,6 +408,21 @@ func Test_ActivationKeyLogger_shouldActivate_verbosity(t *testing.T) {
 			},
 			ExpectedResult: false,
 		},
+
+		// Case 4, activation verbosity defined, but keyVals verbosity
+		// undefined. Results in true.
+		{
+			Activations: map[string]interface{}{
+				"verbosity": 6,
+			},
+			KeyVals: []interface{}{
+				"level",
+				"info",
+				"message",
+				"test",
+			},
+			ExpectedResult: true,
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
I'd argue `verbosity` is used to hide messages with **increased** verbosity (>0) from default output. Therefore if a call to `Log` does not define `verbosity`, it should be logged. This is doubly true since messages are already filtered by level.

Example:
`logger.Log("level", "info", "message", "Hi!")` should be activated only by `"level"`.

## Checklist

- [x] Update changelog in CHANGELOG.md.
