### PR TITLE
Add convenience shorthands for common log levels

### DIFF
--- a/.github/workflows/zz_generated.gitleaks.yaml
+++ b/.github/workflows/zz_generated.gitleaks.yaml
@@ -1,0 +1,17 @@
+# DO NOT EDIT. Generated with:
+#
+#    devctl gen workflows
+#
+name: gitleaks
+
+on: [push,pull_request]
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+    - name: gitleaks-action
+      uses: zricethezav/gitleaks-action@v1.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Convenience shorthands for common log levels added to Logger.
+
 ## [0.3.4] - 2020-11-05
 
 ### Fixed

--- a/activation_logger.go
+++ b/activation_logger.go
@@ -89,7 +89,11 @@ func (l *activationLogger) Debugf(ctx context.Context, format string, params ...
 }
 
 func (l *activationLogger) Errorf(ctx context.Context, err error, format string, params ...interface{}) {
-	l.LogCtx(ctx, "level", "error", "message", fmt.Sprintf(format, params...), "stack", microerror.JSON(err))
+	if err != nil {
+		l.LogCtx(ctx, "level", "error", "message", fmt.Sprintf(format, params...), "stack", microerror.JSON(err))
+	} else {
+		l.LogCtx(ctx, "level", "error", "message", fmt.Sprintf(format, params...))
+	}
 }
 
 func (l *activationLogger) Log(keyVals ...interface{}) {

--- a/activation_logger.go
+++ b/activation_logger.go
@@ -46,8 +46,6 @@ type activationLogger struct {
 type ctxActivationLogger struct {
 	ctx        context.Context
 	underlying Logger
-
-	activations map[string]interface{}
 }
 
 // NewActivation creates a new activation key logger. This logger kind can be

--- a/activation_logger.go
+++ b/activation_logger.go
@@ -43,11 +43,6 @@ type activationLogger struct {
 	activations map[string]interface{}
 }
 
-type ctxActivationLogger struct {
-	ctx        context.Context
-	underlying Logger
-}
-
 // NewActivation creates a new activation key logger. This logger kind can be
 // used on command line tools to improve situations in which log filtering using
 // other command line tools like grep is not sufficient. Due to certain filter
@@ -87,20 +82,12 @@ func NewActivation(config ActivationLoggerConfig) (Logger, error) {
 	return l, nil
 }
 
-func (l *activationLogger) Debug(format string, params ...interface{}) {
-	l.Log("level", "debug", "message", fmt.Sprintf(format, params...))
+func (l *activationLogger) Debugf(ctx context.Context, format string, params ...interface{}) {
+	l.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf(format, params...))
 }
 
-func (l *activationLogger) Info(format string, params ...interface{}) {
-	l.Log("level", "info", "message", fmt.Sprintf(format, params...))
-}
-
-func (l *activationLogger) Warning(format string, params ...interface{}) {
-	l.Log("level", "warning", "message", fmt.Sprintf(format, params...))
-}
-
-func (l *activationLogger) Error(err error, format string, params ...interface{}) {
-	l.Log("level", "error", "message", fmt.Sprintf(format, params...), "stack", microerror.JSON(err))
+func (l *activationLogger) Errorf(ctx context.Context, err error, format string, params ...interface{}) {
+	l.LogCtx(ctx, "level", "error", "message", fmt.Sprintf(format, params...), "stack", microerror.JSON(err))
 }
 
 func (l *activationLogger) Log(keyVals ...interface{}) {
@@ -127,48 +114,6 @@ func (l *activationLogger) LogCtx(ctx context.Context, keyVals ...interface{}) {
 
 func (l *activationLogger) With(keyVals ...interface{}) Logger {
 	return l.underlying.With(keyVals...)
-}
-
-func (l *activationLogger) WithCtx(ctx context.Context) Logger {
-	return &ctxActivationLogger{
-		ctx:        ctx,
-		underlying: l,
-	}
-}
-
-func (l *ctxActivationLogger) Debug(format string, params ...interface{}) {
-	l.LogCtx(l.ctx, "level", "debug", "message", fmt.Sprintf(format, params...))
-}
-
-func (l *ctxActivationLogger) Info(format string, params ...interface{}) {
-	l.LogCtx(l.ctx, "level", "info", "message", fmt.Sprintf(format, params...))
-}
-
-func (l *ctxActivationLogger) Warning(format string, params ...interface{}) {
-	l.LogCtx(l.ctx, "level", "warning", "message", fmt.Sprintf(format, params...))
-}
-
-func (l *ctxActivationLogger) Error(err error, format string, params ...interface{}) {
-	l.LogCtx(l.ctx, "level", "error", "message", fmt.Sprintf(format, params...), "stack", microerror.JSON(err))
-}
-
-func (l *ctxActivationLogger) Log(keyVals ...interface{}) {
-	l.underlying.Log(keyVals...)
-}
-
-func (l *ctxActivationLogger) LogCtx(ctx context.Context, keyVals ...interface{}) {
-	l.underlying.LogCtx(ctx, keyVals...)
-}
-
-func (l *ctxActivationLogger) With(keyVals ...interface{}) Logger {
-	return l.underlying.With(keyVals...)
-}
-
-func (l *ctxActivationLogger) WithCtx(ctx context.Context) Logger {
-	return &ctxActivationLogger{
-		ctx:        ctx,
-		underlying: l,
-	}
 }
 
 func valueFor(keyVals []interface{}, key string) (interface{}, bool) {

--- a/activation_logger.go
+++ b/activation_logger.go
@@ -99,8 +99,8 @@ func (l *activationLogger) Warning(format string, params ...interface{}) {
 	l.Log("level", "warning", "message", fmt.Sprintf(format, params...))
 }
 
-func (l *activationLogger) Error(format string, params ...interface{}) {
-	l.Log("level", "error", "message", fmt.Sprintf(format, params...))
+func (l *activationLogger) Error(err error, format string, params ...interface{}) {
+	l.Log("level", "error", "message", fmt.Sprintf(format, params...), "stack", microerror.JSON(err))
 }
 
 func (l *activationLogger) Log(keyVals ...interface{}) {
@@ -148,8 +148,8 @@ func (l *ctxActivationLogger) Warning(format string, params ...interface{}) {
 	l.LogCtx(l.ctx, "level", "warning", "message", fmt.Sprintf(format, params...))
 }
 
-func (l *ctxActivationLogger) Error(format string, params ...interface{}) {
-	l.LogCtx(l.ctx, "level", "error", "message", fmt.Sprintf(format, params...))
+func (l *ctxActivationLogger) Error(err error, format string, params ...interface{}) {
+	l.LogCtx(l.ctx, "level", "error", "message", fmt.Sprintf(format, params...), "stack", microerror.JSON(err))
 }
 
 func (l *ctxActivationLogger) Log(keyVals ...interface{}) {

--- a/activation_logger.go
+++ b/activation_logger.go
@@ -77,6 +77,8 @@ func NewActivation(config ActivationLoggerConfig) (Logger, error) {
 
 	l := &activationLogger{
 		underlying: config.Underlying,
+
+		activations: config.Activations,
 	}
 
 	return l, nil

--- a/activation_logger.go
+++ b/activation_logger.go
@@ -2,6 +2,7 @@ package micrologger
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/giantswarm/microerror"
@@ -42,6 +43,13 @@ type activationLogger struct {
 	activations map[string]interface{}
 }
 
+type ctxActivationLogger struct {
+	ctx        context.Context
+	underlying Logger
+
+	activations map[string]interface{}
+}
+
 // NewActivation creates a new activation key logger. This logger kind can be
 // used on command line tools to improve situations in which log filtering using
 // other command line tools like grep is not sufficient. Due to certain filter
@@ -76,11 +84,25 @@ func NewActivation(config ActivationLoggerConfig) (Logger, error) {
 
 	l := &activationLogger{
 		underlying: config.Underlying,
-
-		activations: config.Activations,
 	}
 
 	return l, nil
+}
+
+func (l *activationLogger) Debug(format string, params ...interface{}) {
+	l.Log("level", "debug", "message", fmt.Sprintf(format, params...))
+}
+
+func (l *activationLogger) Info(format string, params ...interface{}) {
+	l.Log("level", "info", "message", fmt.Sprintf(format, params...))
+}
+
+func (l *activationLogger) Warning(format string, params ...interface{}) {
+	l.Log("level", "warning", "message", fmt.Sprintf(format, params...))
+}
+
+func (l *activationLogger) Error(format string, params ...interface{}) {
+	l.Log("level", "error", "message", fmt.Sprintf(format, params...))
 }
 
 func (l *activationLogger) Log(keyVals ...interface{}) {
@@ -107,6 +129,48 @@ func (l *activationLogger) LogCtx(ctx context.Context, keyVals ...interface{}) {
 
 func (l *activationLogger) With(keyVals ...interface{}) Logger {
 	return l.underlying.With(keyVals...)
+}
+
+func (l *activationLogger) WithCtx(ctx context.Context) Logger {
+	return &ctxActivationLogger{
+		ctx:        ctx,
+		underlying: l,
+	}
+}
+
+func (l *ctxActivationLogger) Debug(format string, params ...interface{}) {
+	l.LogCtx(l.ctx, "level", "debug", "message", fmt.Sprintf(format, params...))
+}
+
+func (l *ctxActivationLogger) Info(format string, params ...interface{}) {
+	l.LogCtx(l.ctx, "level", "info", "message", fmt.Sprintf(format, params...))
+}
+
+func (l *ctxActivationLogger) Warning(format string, params ...interface{}) {
+	l.LogCtx(l.ctx, "level", "warning", "message", fmt.Sprintf(format, params...))
+}
+
+func (l *ctxActivationLogger) Error(format string, params ...interface{}) {
+	l.LogCtx(l.ctx, "level", "error", "message", fmt.Sprintf(format, params...))
+}
+
+func (l *ctxActivationLogger) Log(keyVals ...interface{}) {
+	l.underlying.Log(keyVals...)
+}
+
+func (l *ctxActivationLogger) LogCtx(ctx context.Context, keyVals ...interface{}) {
+	l.underlying.LogCtx(ctx, keyVals...)
+}
+
+func (l *ctxActivationLogger) With(keyVals ...interface{}) Logger {
+	return l.underlying.With(keyVals...)
+}
+
+func (l *ctxActivationLogger) WithCtx(ctx context.Context) Logger {
+	return &ctxActivationLogger{
+		ctx:        ctx,
+		underlying: l,
+	}
 }
 
 func valueFor(keyVals []interface{}, key string) (interface{}, bool) {

--- a/logger.go
+++ b/logger.go
@@ -8,9 +8,9 @@ import (
 	"io"
 	"log"
 
+	"github.com/giantswarm/microerror"
 	kitlog "github.com/go-kit/kit/log"
 
-	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger/loggermeta"
 )
 

--- a/logger.go
+++ b/logger.go
@@ -54,7 +54,11 @@ func (l *MicroLogger) Debugf(ctx context.Context, format string, params ...inter
 }
 
 func (l *MicroLogger) Errorf(ctx context.Context, err error, format string, params ...interface{}) {
-	l.LogCtx(ctx, "level", "error", "message", fmt.Sprintf(format, params...), "stack", microerror.JSON(err))
+	if err != nil {
+		l.LogCtx(ctx, "level", "error", "message", fmt.Sprintf(format, params...), "stack", microerror.JSON(err))
+	} else {
+		l.LogCtx(ctx, "level", "error", "message", fmt.Sprintf(format, params...))
+	}
 }
 
 func (l *MicroLogger) Log(keyVals ...interface{}) {

--- a/logger.go
+++ b/logger.go
@@ -24,11 +24,6 @@ type MicroLogger struct {
 	logger kitlog.Logger
 }
 
-type CtxMicroLogger struct {
-	ctx        context.Context
-	underlying Logger
-}
-
 func New(config Config) (*MicroLogger, error) {
 	if config.Caller == nil {
 		config.Caller = DefaultCaller
@@ -54,20 +49,12 @@ func New(config Config) (*MicroLogger, error) {
 	return l, nil
 }
 
-func (l *MicroLogger) Debug(format string, params ...interface{}) {
-	l.Log("level", "debug", "message", fmt.Sprintf(format, params...))
+func (l *MicroLogger) Debugf(ctx context.Context, format string, params ...interface{}) {
+	l.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf(format, params...))
 }
 
-func (l *MicroLogger) Info(format string, params ...interface{}) {
-	l.Log("level", "info", "message", fmt.Sprintf(format, params...))
-}
-
-func (l *MicroLogger) Warning(format string, params ...interface{}) {
-	l.Log("level", "warning", "message", fmt.Sprintf(format, params...))
-}
-
-func (l *MicroLogger) Error(err error, format string, params ...interface{}) {
-	l.Log("level", "error", "message", fmt.Sprintf(format, params...), "stack", microerror.JSON(err))
+func (l *MicroLogger) Errorf(ctx context.Context, err error, format string, params ...interface{}) {
+	l.LogCtx(ctx, "level", "error", "message", fmt.Sprintf(format, params...), "stack", microerror.JSON(err))
 }
 
 func (l *MicroLogger) Log(keyVals ...interface{}) {
@@ -112,13 +99,6 @@ func (l *MicroLogger) With(keyVals ...interface{}) Logger {
 	}
 }
 
-func (l *MicroLogger) WithCtx(ctx context.Context) Logger {
-	return &CtxMicroLogger{
-		ctx:        ctx,
-		underlying: l,
-	}
-}
-
 func (l *MicroLogger) processStack(keyVals []interface{}) []interface{} {
 	for i := 1; i < len(keyVals); i += 2 {
 		k := keyVals[i-1]
@@ -158,39 +138,4 @@ func (l *MicroLogger) processStack(keyVals []interface{}) []interface{} {
 	}
 
 	return keyVals
-}
-
-func (l *CtxMicroLogger) Debug(format string, params ...interface{}) {
-	l.LogCtx(l.ctx, "level", "debug", "message", fmt.Sprintf(format, params...))
-}
-
-func (l *CtxMicroLogger) Info(format string, params ...interface{}) {
-	l.LogCtx(l.ctx, "level", "info", "message", fmt.Sprintf(format, params...))
-}
-
-func (l *CtxMicroLogger) Warning(format string, params ...interface{}) {
-	l.LogCtx(l.ctx, "level", "warning", "message", fmt.Sprintf(format, params...))
-}
-
-func (l *CtxMicroLogger) Error(err error, format string, params ...interface{}) {
-	l.LogCtx(l.ctx, "level", "error", "message", fmt.Sprintf(format, params...), "stack", microerror.JSON(err))
-}
-
-func (l *CtxMicroLogger) Log(keyVals ...interface{}) {
-	l.underlying.Log(keyVals...)
-}
-
-func (l *CtxMicroLogger) LogCtx(ctx context.Context, keyVals ...interface{}) {
-	l.underlying.LogCtx(ctx, keyVals...)
-}
-
-func (l *CtxMicroLogger) With(keyVals ...interface{}) Logger {
-	return l.underlying.With(keyVals...)
-}
-
-func (l *CtxMicroLogger) WithCtx(ctx context.Context) Logger {
-	return &CtxMicroLogger{
-		ctx:        ctx,
-		underlying: l,
-	}
 }

--- a/logger.go
+++ b/logger.go
@@ -10,6 +10,7 @@ import (
 
 	kitlog "github.com/go-kit/kit/log"
 
+	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger/loggermeta"
 )
 
@@ -65,8 +66,8 @@ func (l *MicroLogger) Warning(format string, params ...interface{}) {
 	l.Log("level", "warning", "message", fmt.Sprintf(format, params...))
 }
 
-func (l *MicroLogger) Error(format string, params ...interface{}) {
-	l.Log("level", "error", "message", fmt.Sprintf(format, params...))
+func (l *MicroLogger) Error(err error, format string, params ...interface{}) {
+	l.Log("level", "error", "message", fmt.Sprintf(format, params...), "stack", microerror.JSON(err))
 }
 
 func (l *MicroLogger) Log(keyVals ...interface{}) {
@@ -171,8 +172,8 @@ func (l *CtxMicroLogger) Warning(format string, params ...interface{}) {
 	l.LogCtx(l.ctx, "level", "warning", "message", fmt.Sprintf(format, params...))
 }
 
-func (l *CtxMicroLogger) Error(format string, params ...interface{}) {
-	l.LogCtx(l.ctx, "level", "error", "message", fmt.Sprintf(format, params...))
+func (l *CtxMicroLogger) Error(err error, format string, params ...interface{}) {
+	l.LogCtx(l.ctx, "level", "error", "message", fmt.Sprintf(format, params...), "stack", microerror.JSON(err))
 }
 
 func (l *CtxMicroLogger) Log(keyVals ...interface{}) {

--- a/logger.go
+++ b/logger.go
@@ -4,6 +4,7 @@ package micrologger
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 
@@ -20,6 +21,11 @@ type Config struct {
 
 type MicroLogger struct {
 	logger kitlog.Logger
+}
+
+type CtxMicroLogger struct {
+	ctx        context.Context
+	underlying Logger
 }
 
 func New(config Config) (*MicroLogger, error) {
@@ -45,6 +51,22 @@ func New(config Config) (*MicroLogger, error) {
 	}
 
 	return l, nil
+}
+
+func (l *MicroLogger) Debug(format string, params ...interface{}) {
+	l.Log("level", "debug", "message", fmt.Sprintf(format, params...))
+}
+
+func (l *MicroLogger) Info(format string, params ...interface{}) {
+	l.Log("level", "info", "message", fmt.Sprintf(format, params...))
+}
+
+func (l *MicroLogger) Warning(format string, params ...interface{}) {
+	l.Log("level", "warning", "message", fmt.Sprintf(format, params...))
+}
+
+func (l *MicroLogger) Error(format string, params ...interface{}) {
+	l.Log("level", "error", "message", fmt.Sprintf(format, params...))
 }
 
 func (l *MicroLogger) Log(keyVals ...interface{}) {
@@ -89,6 +111,13 @@ func (l *MicroLogger) With(keyVals ...interface{}) Logger {
 	}
 }
 
+func (l *MicroLogger) WithCtx(ctx context.Context) Logger {
+	return &CtxMicroLogger{
+		ctx:        ctx,
+		underlying: l,
+	}
+}
+
 func (l *MicroLogger) processStack(keyVals []interface{}) []interface{} {
 	for i := 1; i < len(keyVals); i += 2 {
 		k := keyVals[i-1]
@@ -128,4 +157,39 @@ func (l *MicroLogger) processStack(keyVals []interface{}) []interface{} {
 	}
 
 	return keyVals
+}
+
+func (l *CtxMicroLogger) Debug(format string, params ...interface{}) {
+	l.LogCtx(l.ctx, "level", "debug", "message", fmt.Sprintf(format, params...))
+}
+
+func (l *CtxMicroLogger) Info(format string, params ...interface{}) {
+	l.LogCtx(l.ctx, "level", "info", "message", fmt.Sprintf(format, params...))
+}
+
+func (l *CtxMicroLogger) Warning(format string, params ...interface{}) {
+	l.LogCtx(l.ctx, "level", "warning", "message", fmt.Sprintf(format, params...))
+}
+
+func (l *CtxMicroLogger) Error(format string, params ...interface{}) {
+	l.LogCtx(l.ctx, "level", "error", "message", fmt.Sprintf(format, params...))
+}
+
+func (l *CtxMicroLogger) Log(keyVals ...interface{}) {
+	l.underlying.Log(keyVals...)
+}
+
+func (l *CtxMicroLogger) LogCtx(ctx context.Context, keyVals ...interface{}) {
+	l.underlying.LogCtx(ctx, keyVals...)
+}
+
+func (l *CtxMicroLogger) With(keyVals ...interface{}) Logger {
+	return l.underlying.With(keyVals...)
+}
+
+func (l *CtxMicroLogger) WithCtx(ctx context.Context) Logger {
+	return &CtxMicroLogger{
+		ctx:        ctx,
+		underlying: l,
+	}
 }

--- a/spec.go
+++ b/spec.go
@@ -5,6 +5,14 @@ import "context"
 // Logger is a simple interface describing services that emit messages to
 // gather certain runtime information.
 type Logger interface {
+	// Debug takes a format string and parameters and writes them in debug level.
+	Debug(format string, params ...interface{})
+	// Info takes a format string and parameters and writes them in info level.
+	Info(format string, params ...interface{})
+	// Warning takes a format string and parameters and writes them in warning level.
+	Warning(format string, params ...interface{})
+	// Error takes a format string and parameters and writes them in error level.
+	Error(format string, params ...interface{})
 	// Log takes a sequence of alternating key/value pairs which are used
 	// to create the log message structure.
 	Log(keyVals ...interface{})
@@ -16,4 +24,6 @@ type Logger interface {
 	// passed to calls to Log. If logger is also a contextual logger
 	// created by With, keyVals is appended to the existing context.
 	With(keyVals ...interface{}) Logger
+	// WithCtx returns a context specific logger for given parameter.
+	WithCtx(ctx context.Context) Logger
 }

--- a/spec.go
+++ b/spec.go
@@ -5,16 +5,13 @@ import "context"
 // Logger is a simple interface describing services that emit messages to
 // gather certain runtime information.
 type Logger interface {
-	// Debug takes a format string and parameters and writes them in debug level.
-	Debug(format string, params ...interface{})
-	// Info takes a format string and parameters and writes them in info level.
-	Info(format string, params ...interface{})
-	// Warning takes a format string and parameters and writes them in warning level.
-	Warning(format string, params ...interface{})
-	// Error takes an error, a format string and parameters and writes them in
+	// Debugf takes a format string and parameters and writes them in debug
+	// level.
+	Debugf(ctx context.Context, format string, params ...interface{})
+	// Errorf takes an error, a format string and parameters and writes them in
 	// error level. The error stack trace is written as "stack" value log
 	// entry.
-	Error(err error, format string, params ...interface{})
+	Errorf(ctx context.Context, err error, format string, params ...interface{})
 	// Log takes a sequence of alternating key/value pairs which are used
 	// to create the log message structure.
 	Log(keyVals ...interface{})
@@ -26,6 +23,4 @@ type Logger interface {
 	// passed to calls to Log. If logger is also a contextual logger
 	// created by With, keyVals is appended to the existing context.
 	With(keyVals ...interface{}) Logger
-	// WithCtx returns a context specific logger for given parameter.
-	WithCtx(ctx context.Context) Logger
 }

--- a/spec.go
+++ b/spec.go
@@ -11,8 +11,10 @@ type Logger interface {
 	Info(format string, params ...interface{})
 	// Warning takes a format string and parameters and writes them in warning level.
 	Warning(format string, params ...interface{})
-	// Error takes a format string and parameters and writes them in error level.
-	Error(format string, params ...interface{})
+	// Error takes an error, a format string and parameters and writes them in
+	// error level. The error stack trace is written as "stack" value log
+	// entry.
+	Error(err error, format string, params ...interface{})
 	// Log takes a sequence of alternating key/value pairs which are used
 	// to create the log message structure.
 	Log(keyVals ...interface{})


### PR DESCRIPTION
This change provides some convenience shorthands for commonly used log
levels in `Logger` interface.

When we would before write:
    `r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating App CR %#q in namespace %#q", appCR.Name, appCR.Namespace))`
we can now write:
    `r.logger.WithCtx(ctx).Debug("creating App CR %#q in namespace %#q", appCR.Name, appCR.Namespace)`

Same without context:
    `s.logger.Log("level", "debug", "message", "collecting metrics")`
we can now write:
    `s.logger.Debug("collecting metrics")`

## Checklist

- [x] Update changelog in CHANGELOG.md.
