### PR TITLE
log to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change DefaultIOWriter from Stdout to Stderr.
+
 ## [0.6.0] - 2021-12-14
 
 ### Changed

--- a/default.go
+++ b/default.go
@@ -9,7 +9,7 @@ import (
 
 var DefaultCaller = newCallerFunc(0)
 
-var DefaultIOWriter = os.Stdout
+var DefaultIOWriter = os.Stderr
 
 var DefaultTimestampFormatter kitlog.Valuer = func() interface{} {
 	return time.Now().UTC().Format("2006-01-02T15:04:05.999999-07:00")


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20840

Log messages should be written to `stderr` by default.